### PR TITLE
remove turbolinks load, remove turbolinks event listeners

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -42,57 +42,46 @@
 
         var responsiveMenu = function() {
             var menuType = 'desktop';
-            // $(window).on('load resize', function() {
-            //     var currMenuType = 'desktop';
-            //     if ( matchMedia( 'only screen and (max-width: 991px)' ).matches ) {
-            //         currMenuType = 'mobile';
-            //     }
 
-            //     if ( currMenuType !== menuType ) {
-            //         menuType = currMenuType;
+            $(window).on('load resize', function() {
+                var currMenuType = 'desktop';
 
-            //         if ( currMenuType === 'mobile' ) {
-            //             var $mobileMenu = $('#mainnav').attr('id', 'mainnav-mobi').hide();
-            //             var hasChildMenu = $('#mainnav-mobi').find('li:has(ul)');
-            //             $('.header').after($mobileMenu);
-            //             hasChildMenu.children('ul').hide();
-            //             $('.header').find('.button-header').hide();
-            //             $('.header').find('#button-header-mobile').attr('display', 'block');
-            //             hasChildMenu.children('a').after('<span class="btn-submenu"></span>');
-            //             $('.btn-menu').removeClass('active');
-            //             $('.btn-menu').show();
-            //         } else {
-            //             var $desktopMenu = $('#mainnav-mobi').attr('id', 'mainnav').removeAttr('style');
-            //             $('.header').find('.button-header').show();
-            //             $('.header').find('#button-header-mobile').attr('display', 'none');
-            //             $desktopMenu.find('.submenu').removeAttr('style');
-            //             $('.header').find('.button-header').before($desktopMenu);
-            //             $('.btn-submenu').remove();
-            //             $('.btn-menu').hide();
-            //         }
-            //     }
-            // });
+                if ( matchMedia( 'only screen and (max-width: 991px)' ).matches ) {
+                    currMenuType = 'mobile';
+                }
 
-            // $('.btn-menu').on('click', function() {
-            //     $('#mainnav-mobi').slideToggle(300);
-            //     console.log('hi');;
-            //     $(this).toggleClass('active');
-            //     return false;
-            // });
-          document.addEventListener('turbolinks:load', function() {
-            document.querySelector('.btn-menu').addEventListener('click', function() {
-              $('#mainnav-mobi').slideToggle(300);
-                // console.log('hi');;
-                // $(this).toggleClass('active');
-                // return false;
-            })
+                if ( currMenuType !== menuType ) {
+                    menuType = currMenuType;
+
+                    if ( currMenuType === 'mobile' ) {
+                        var $mobileMenu = $('#mainnav').attr('id', 'mainnav-mobi').hide();
+                        var hasChildMenu = $('#mainnav-mobi').find('li:has(ul)');
+
+                        $('.header').after($mobileMenu);
+                        hasChildMenu.children('ul').hide();
+                        hasChildMenu.children('a').after('<span class="btn-submenu"></span>');
+                        $('.btn-menu').removeClass('active');
+                    } else {
+                        var $desktopMenu = $('#mainnav-mobi').attr('id', 'mainnav').removeAttr('style');
+
+                        $desktopMenu.find('.submenu').removeAttr('style');
+                        $('.header').find('.button-header').before($desktopMenu);
+                        $('.btn-submenu').remove();
+                    }
+                }
+            });
+
+            $('.btn-menu').on('click', function() {
+                $('#mainnav-mobi').slideToggle(300);
+                $(this).toggleClass('active');
+                return false;
+            });
 
             $(document).on('click', '#mainnav-mobi li .btn-submenu', function(e) {
                 $(this).toggleClass('active').next('ul').slideToggle(300);
-                // e.stopImmediatePropagation();
+                e.stopImmediatePropagation();
                 return false;
             });
-          })
         }; // Responsive Menu
 
         var headerFixed = function() {
@@ -155,7 +144,6 @@
         }; // Slide Team
 
         var searchButton = function() {
-          document.addEventListener('turbolinks:load', function() {
             var showsearch = $('.show-search button');
                 showsearch.on('click',function() {
                 $('.show-search .top-search').toggleClass('active');
@@ -169,7 +157,6 @@
                     $(this).children('span').removeClass('ti-close');
                 }
             });
-          })
         }; // Search Button
 
         var CountDown = function() {
@@ -1026,7 +1013,7 @@
         }; // Slide Search
 
         var loadMore = function () {
-            $(".wrap-imagebox.style1 .imagebox.style3").show();
+            $(".wrap-imagebox.style1 .imagebox.style3").slice(0, 4).show();
             $(".wrap-imagebox.style1 .btn-more").on('click', function (e) {
                 e.preventDefault();
                 $(".wrap-imagebox.style1 .imagebox.style3:hidden").slice(0, 2).slideDown(600);
@@ -1143,4 +1130,5 @@
         goTop();
         removePreloader();
     });
+
 })(jQuery);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,16 +1,14 @@
 import "bootstrap";
 import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import { spaceQuery } from '../components/space_query.js'
 import { autocomplete } from '../plugins/autocomplete';
 import { chatController } from '../components/chat_controller';
 import { bookingController } from '../components/booking_controller';
 import "../plugins/flatpickr"
 
-Turbolinks.start();
 Rails.start();
 
-document.addEventListener('turbolinks:load', () => {
+document.addEventListener('DOMContentLoaded', () => {
   spaceQuery.startListening();
   bookingController.initialize();
 });

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -1,7 +1,7 @@
 import { autocomplete } from '../plugins/autocomplete';
 import GMaps from 'gmaps/gmaps.js';
 
-document.addEventListener('turbolinks:load', () => {
+document.addEventListener('DOMContentLoaded', () => {
   const mapElement = document.getElementById('map');
   if (mapElement) { // don't try to build a map if there's no div#map to inject in
     const map = new GMaps({ el: '#map', lat: 0, lng: 0 });

--- a/app/javascript/plugins/autocomplete.js
+++ b/app/javascript/plugins/autocomplete.js
@@ -1,5 +1,5 @@
 function autocomplete() {
-  document.addEventListener("turbolinks:load", function() {
+  document.addEventListener("DOMContentLoaded", function() {
     var spaceAutocomplete = document.getElementById('space_address_autocomplete');
 
     if (spaceAutocomplete) {

--- a/app/javascript/plugins/flatpickr.js
+++ b/app/javascript/plugins/flatpickr.js
@@ -1,7 +1,7 @@
 import flatpickr from "flatpickr"
 import "flatpickr/dist/flatpickr.min.css" // Note this is important!
 
-document.addEventListener('turbolinks:load', () => {
+document.addEventListener('DOMContentLoaded', () => {
   flatpickr(".datepicker", {
     minDate: "today"
   })

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,10 +10,6 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= stylesheet_pack_tag 'application' %>
 
-    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places&key=#{ENV['GOOGLE_BROWSER_KEY']}" %>
-    <%= javascript_include_tag 'application' %>
-    <%= javascript_pack_tag "application" %>
-    <%= javascript_pack_tag "map" %>
   </head>
   <body class="header_sticky">
     <%= render 'shared/navbar' %>
@@ -23,4 +19,8 @@
     </div>
     <%= render 'shared/footer' %>
   </body>
+  <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places&key=#{ENV['GOOGLE_BROWSER_KEY']}" %>
+  <%= javascript_include_tag 'application' %>
+  <%= javascript_pack_tag "application" %>
+  <%= javascript_pack_tag "map" %>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "flatpickr": "^4.5.1",
     "gmaps": "^0.4.24",
     "jquery": "^3.3.1",
-    "rails-ujs": "^5.2.1",
-    "turbolinks": "^5.1.1"
+    "rails-ujs": "^5.2.1"
   },
   "devDependencies": {
     "webpack-dev-server": "2.11.2"


### PR DESCRIPTION
Removed the turbolinks library as adding the library was giving a lot of errors with use of the template's JS. Website significantly slower, but rewriting the JS would have been out of scope. 

Perhaps to be added back later. 